### PR TITLE
MC-20185 Adds shared dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Canada/Eastern"
+    open-pull-requests-limit: 5
+    target-branch: "devel"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Canada/Eastern"
+    open-pull-requests-limit: 5
+    target-branch: "devel"


### PR DESCRIPTION
### Fixes [MC-20185](https://cloud-ops.atlassian.net/browse/MC-20185)

#### Code walkthrough : @INSERT_NAME
<!-- Remember that, related PRs should include a common set of reviewers -->

#### Issue
Currently each repo has its own dependabot workflow file. Making changes is really tedious.

#### Solution
Create a shared dependabot config, this will be the default workflow. Repos can overwrite as needed.

#### Test cases
not yet :)

#### UI changes
No changes

<!-- Uncomment if PRs from other repos related to the same story 
#### Related PRs
- PR #
-->
